### PR TITLE
add vllm observability example

### DIFF
--- a/vllm/00_setup.sh
+++ b/vllm/00_setup.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo -e "${GREEN}=== vLLM + OpenTelemetry Demo Setup ===${NC}"
+echo ""
+
+# Check Docker
+if ! command -v docker &>/dev/null; then
+    echo -e "${RED}❌ docker is not installed${NC}"
+    echo "Install from: https://docs.docker.com/get-docker/"
+    exit 1
+fi
+echo -e "${GREEN}✓ docker found${NC}"
+
+# Check Docker Compose (plugin or standalone)
+if docker compose version &>/dev/null 2>&1; then
+    COMPOSE_CMD="docker compose"
+elif command -v docker-compose &>/dev/null; then
+    COMPOSE_CMD="docker-compose"
+else
+    echo -e "${RED}❌ Docker Compose not found${NC}"
+    echo "Install from: https://docs.docker.com/compose/install/"
+    exit 1
+fi
+echo -e "${GREEN}✓ Docker Compose found (${COMPOSE_CMD})${NC}"
+
+# Check NVIDIA GPU
+if ! command -v nvidia-smi &>/dev/null; then
+    echo -e "${RED}❌ nvidia-smi not found — this demo requires an NVIDIA GPU${NC}"
+    echo "  For testing without local hardware, a g4dn.xlarge EC2 instance (~\$0.50/hr) works well."
+    exit 1
+fi
+if ! nvidia-smi --query-gpu=name --format=csv,noheader &>/dev/null; then
+    echo -e "${RED}❌ NVIDIA driver not responding. Check your GPU drivers.${NC}"
+    exit 1
+fi
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)
+echo -e "${GREEN}✓ NVIDIA GPU detected: ${GPU_NAME}${NC}"
+
+# Check .env file
+ENV_FILE="${SCRIPT_DIR}/../.env"
+if [ ! -f "$ENV_FILE" ]; then
+    echo ""
+    echo -e "${RED}❌ .env file not found at ${ENV_FILE}${NC}"
+    echo ""
+    echo "Create it with the following content:"
+    echo ""
+    echo "  DASH0_AUTH_TOKEN=your_auth_token_here"
+    echo "  DASH0_DATASET=default"
+    echo "  DASH0_ENDPOINT_OTLP_GRPC_HOSTNAME=ingress.eu-west-1.aws.dash0.com"
+    echo "  DASH0_ENDPOINT_OTLP_GRPC_PORT=4317"
+    echo ""
+    echo "Get your auth token from https://app.dash0.com/settings"
+    exit 1
+fi
+
+# Validate required variables
+set -a
+source "$ENV_FILE"
+set +a
+
+missing=0
+for var in DASH0_AUTH_TOKEN DASH0_ENDPOINT_OTLP_GRPC_HOSTNAME DASH0_ENDPOINT_OTLP_GRPC_PORT; do
+    if [ -z "${!var}" ]; then
+        echo -e "${RED}❌ ${var} is not set in ${ENV_FILE}${NC}"
+        missing=1
+    else
+        echo -e "${GREEN}✓ ${var} is set${NC}"
+    fi
+done
+if [ "$missing" -eq 1 ]; then exit 1; fi
+
+echo ""
+echo -e "${BLUE}Starting the stack...${NC}"
+cd "$SCRIPT_DIR"
+$COMPOSE_CMD up --build -d
+
+echo ""
+echo -e "${GREEN}Stack is starting.${NC}"
+echo ""
+echo "vLLM takes 2–5 minutes to load the model on first run. Follow the logs:"
+echo ""
+echo "  $COMPOSE_CMD logs -f vllm"
+echo ""
+echo "When you see 'Application startup complete.', the server is ready."
+echo ""
+echo "Send test requests:"
+echo ""
+echo "  python scripts/send-request.py"
+echo ""
+echo "Then check Dash0 for:"
+echo "  Traces  — filter by service.name = rag-app or vllm-server"
+echo "  Metrics — search for vllm:* or rag_queries_total"
+echo ""
+echo "To stop: ./01_cleanup.sh"

--- a/vllm/01_cleanup.sh
+++ b/vllm/01_cleanup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BLUE='\033[0;34m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+echo -e "${BLUE}=== vLLM Demo Cleanup ===${NC}"
+echo ""
+
+cd "$SCRIPT_DIR"
+
+if docker compose version &>/dev/null 2>&1; then
+    COMPOSE_CMD="docker compose"
+elif command -v docker-compose &>/dev/null; then
+    COMPOSE_CMD="docker-compose"
+else
+    echo "Docker Compose not found — nothing to clean up."
+    exit 0
+fi
+
+read -p "Also remove the cached model weights (~500 MB)? [y/N] " -n 1 -r
+echo ""
+
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    $COMPOSE_CMD down -v
+    echo -e "${GREEN}✓ Containers stopped and volumes removed.${NC}"
+else
+    $COMPOSE_CMD down
+    echo -e "${GREEN}✓ Containers stopped. Model weights kept in Docker volume 'huggingface-cache'.${NC}"
+fi

--- a/vllm/README.md
+++ b/vllm/README.md
@@ -1,0 +1,128 @@
+# vLLM + OpenTelemetry + Dash0
+
+Observe a vLLM inference server end-to-end using OpenTelemetry — distributed traces from a FastAPI RAG application through to the vLLM engine, plus Prometheus metrics scraped and forwarded to Dash0.
+
+## What this demonstrates
+
+- Distributed traces spanning a FastAPI RAG app and the vLLM inference server, connected via W3C trace context propagation
+- GenAI semantic convention attributes (`gen_ai.provider.name`, `gen_ai.request.model`, token usage) on LLM spans
+- vLLM's native OTLP trace export via `--otlp-traces-endpoint` (no code changes to the server)
+- Prometheus metrics from vLLM (`vllm:*` metrics family) scraped by the OTel Collector and forwarded to Dash0
+- Custom RAG app metrics (`rag_queries_total`, `rag_query_duration_seconds`) via `prometheus-client`
+- OTel Collector acting as a unified pipeline for both traces (OTLP) and metrics (Prometheus scrape)
+
+## Technologies
+
+- [vLLM](https://docs.vllm.ai/) — high-throughput LLM inference server with native OTel support
+- [OpenTelemetry](https://opentelemetry.io/) — distributed tracing and metrics
+- Python / FastAPI — RAG application with manual OTel instrumentation
+- Docker Compose — local orchestration
+- [Dash0](https://www.dash0.com/) — observability backend
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Dash0 account with an auth token
+- NVIDIA GPU (the vLLM Docker image is CUDA-compiled; a `g4dn.xlarge` on AWS with one T4 is sufficient for testing)
+
+## Quick Start
+
+1. **Set your Dash0 credentials** in the root `.env` file:
+   ```bash
+   DASH0_AUTH_TOKEN=your_auth_token_here
+   DASH0_DATASET=default
+   DASH0_ENDPOINT_OTLP_GRPC_HOSTNAME=ingress.eu-west-1.aws.dash0.com
+   DASH0_ENDPOINT_OTLP_GRPC_PORT=4317
+   ```
+   Get your auth token from [Dash0 settings](https://app.dash0.com/settings).
+
+2. **Run the setup script** from the `vllm/` directory:
+   ```bash
+   cd vllm
+   ./00_setup.sh
+   ```
+   This validates your environment (Docker, NVIDIA GPU, credentials) and starts all services.
+
+3. **Wait for vLLM to finish loading the model.** On first run it downloads `facebook/opt-125m` (~500 MB) and then loads it into GPU memory. Follow the logs:
+   ```bash
+   docker compose logs -f vllm
+   ```
+   Look for this line before sending requests:
+   ```
+   vllm-server  | INFO:     Application startup complete.
+   ```
+   This typically takes 2–5 minutes on first run.
+
+4. **Send test queries:**
+   ```bash
+   python scripts/send-request.py
+   ```
+   Or manually:
+   ```bash
+   curl -X POST http://localhost:8001/query \
+     -H "Content-Type: application/json" \
+     -d '{"query": "What is OpenTelemetry?"}'
+   ```
+
+5. **View telemetry in Dash0:**
+   - **Traces**: filter by `service.name = "rag-app"` or `service.name = "vllm-server"` to see the full request flow
+   - **Metrics**: search for `vllm:*` (inference metrics) or `rag_queries_total` (RAG request counter)
+
+## What you'll see in Dash0
+
+Each query to the RAG app produces a distributed trace with spans across two services:
+
+**rag-app**
+- `POST /query` — auto-instrumented HTTP server span (FastAPIInstrumentor)
+- `rag.query` — top-level RAG span with GenAI attributes
+- `rag.retrieve` — mock document retrieval with `rag.context.length`
+- `rag.generate` — outbound call to vLLM; injects W3C `traceparent` header
+
+**vllm-server**
+- `POST /v1/completions` — vLLM request span, linked via the propagated `traceparent` header
+- `llm_request` — inference span with `gen_ai.*` attributes (model, token counts, finish reason)
+
+The metrics pipeline collects vLLM's built-in Prometheus metrics (request throughput, token counts, cache utilisation) alongside the RAG app's custom counters.
+
+## Architecture
+
+```
+                  ┌─────────────────────┐
+  curl / script ──▶   rag-app :8001     │
+                  │  (FastAPI + OTel)    │
+                  └────────┬────────────┘
+                           │ HTTP + traceparent header
+                           ▼
+                  ┌─────────────────────┐
+                  │  vllm-server :8000   │
+                  │  facebook/opt-125m   │
+                  └────────┬────────────┘
+                           │
+              ┌────────────┴──────────────┐
+              │ OTLP traces (gRPC :4317)  │ Prometheus scrape
+              │ (both services → collector)│ (/metrics on :8000, :8001)
+              ▼                           ▼
+     ┌──────────────────────────────────────────┐
+     │         OTel Collector :4317             │
+     └──────────────────┬───────────────────────┘
+                        │ OTLP gRPC
+                        ▼
+                  ┌──────────┐
+                  │  Dash0   │
+                  └──────────┘
+```
+
+## Cleanup
+
+```bash
+./01_cleanup.sh
+```
+
+This stops all containers and optionally removes the cached model weights (~500 MB Docker volume).
+
+## References
+
+- [vLLM metrics and tracing docs](https://docs.vllm.ai/en/latest/deployment/metrics.html)
+- [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+- [OTel Collector Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver)
+- [Dash0](https://www.dash0.com/)

--- a/vllm/docker-compose.yml
+++ b/vllm/docker-compose.yml
@@ -1,0 +1,82 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.126.0
+    container_name: vllm-otel-collector
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otelcol/config.yaml
+    ports:
+      - "4317:4317"   # OTLP gRPC receiver
+      - "4318:4318"   # OTLP HTTP receiver
+      - "13133:13133" # health check
+    env_file:
+      - ../.env
+    networks:
+      - vllm-demo
+
+  vllm:
+    build: ./vllm-server
+    container_name: vllm-server
+    command:
+      - "--model"
+      - "facebook/opt-125m"
+      - "--port"
+      - "8000"
+      - "--otlp-traces-endpoint"
+      - "http://otel-collector:4317"
+    environment:
+      OTEL_SERVICE_NAME: vllm-server
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://otel-collector:4317
+      OTEL_EXPORTER_OTLP_TRACES_INSECURE: "true"
+    ports:
+      - "8000:8000"
+    volumes:
+      - huggingface-cache:/root/.cache/huggingface
+    shm_size: "1gb"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 300s  # model loading takes 2-5 min on first run
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    depends_on:
+      - otel-collector
+    networks:
+      - vllm-demo
+
+  rag-app:
+    build: ./rag-app
+    container_name: vllm-rag-app
+    environment:
+      OTEL_SERVICE_NAME: rag-app
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      VLLM_BASE_URL: http://vllm:8000
+    ports:
+      - "8001:8001"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    depends_on:
+      otel-collector:
+        condition: service_started
+      vllm:
+        condition: service_healthy
+    networks:
+      - vllm-demo
+
+volumes:
+  huggingface-cache:
+
+networks:
+  vllm-demo:
+    driver: bridge

--- a/vllm/otel-collector-config.yml
+++ b/vllm/otel-collector-config.yml
@@ -1,0 +1,54 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+  prometheus:
+    config:
+      global:
+        scrape_interval: 15s
+      scrape_configs:
+        - job_name: vllm
+          static_configs:
+            - targets: ["vllm:8000"]
+
+        - job_name: rag-app
+          static_configs:
+            - targets: ["rag-app:8001"]
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+
+exporters:
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 200
+
+  otlp/dash0:
+    endpoint: ${env:DASH0_ENDPOINT_OTLP_GRPC_HOSTNAME}:${env:DASH0_ENDPOINT_OTLP_GRPC_PORT}
+    headers:
+      Authorization: Bearer ${env:DASH0_AUTH_TOKEN}
+      Dash0-Dataset: ${env:DASH0_DATASET}
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, otlp/dash0]
+
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [batch]
+      exporters: [debug, otlp/dash0]

--- a/vllm/rag-app/Dockerfile
+++ b/vllm/rag-app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/vllm/rag-app/app.py
+++ b/vllm/rag-app/app.py
@@ -1,0 +1,110 @@
+import os
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.propagate import inject
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from prometheus_client import Counter, Histogram, make_asgi_app
+from pydantic import BaseModel
+
+# --- OTel setup ---
+# Endpoint and service name are read from OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_SERVICE_NAME env vars
+provider = TracerProvider(resource=Resource.create())
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("rag-app")
+
+# --- Prometheus metrics ---
+RAG_REQUESTS = Counter("rag_queries_total", "Total number of RAG queries received")
+RAG_LATENCY = Histogram("rag_query_duration_seconds", "End-to-end RAG query duration in seconds")
+
+# --- App ---
+app = FastAPI(title="RAG Demo App")
+FastAPIInstrumentor.instrument_app(app, excluded_urls="/metrics,/health")
+app.mount("/metrics", make_asgi_app())
+
+VLLM_BASE_URL = os.getenv("VLLM_BASE_URL", "http://vllm:8000")
+MODEL = "facebook/opt-125m"
+
+DOCS = [
+    "OpenTelemetry is a vendor-neutral observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.",
+    "vLLM is a high-throughput and memory-efficient inference and serving engine for large language models, supporting continuous batching and PagedAttention.",
+    "Distributed tracing tracks requests as they flow across multiple services, providing end-to-end visibility and helping you understand latency and failures.",
+    "Prometheus is an open-source systems monitoring and alerting toolkit that scrapes metrics from instrumented targets at given intervals.",
+    "Dash0 is an OpenTelemetry-native observability platform that stores traces, metrics, and logs without proprietary agents or lock-in.",
+]
+
+
+class QueryRequest(BaseModel):
+    query: str
+
+
+def retrieve(query: str) -> str:
+    query_lower = query.lower()
+    for doc in DOCS:
+        if any(word in doc.lower() for word in query_lower.split() if len(word) > 3):
+            return doc
+    return DOCS[0]
+
+
+@app.post("/query")
+async def query_endpoint(body: QueryRequest):
+    RAG_REQUESTS.inc()
+
+    with RAG_LATENCY.time():
+        with tracer.start_as_current_span(
+            "rag.query",
+            attributes={
+                "gen_ai.provider.name": "vllm",
+                "gen_ai.request.model": MODEL,
+            },
+        ) as span:
+            with tracer.start_as_current_span("rag.retrieve") as retrieve_span:
+                context = retrieve(body.query)
+                retrieve_span.set_attribute("rag.context.length", len(context))
+
+            with tracer.start_as_current_span("rag.generate") as gen_span:
+                # Inject W3C trace context so vLLM spans are linked to this trace
+                headers = {"Content-Type": "application/json"}
+                inject(headers)
+
+                prompt = f"Context: {context}\n\nQuestion: {body.query}\nAnswer:"
+                gen_span.set_attribute("gen_ai.request.max_tokens", 100)
+
+                try:
+                    async with httpx.AsyncClient(timeout=120.0) as client:
+                        resp = await client.post(
+                            f"{VLLM_BASE_URL}/v1/completions",
+                            json={
+                                "model": MODEL,
+                                "prompt": prompt,
+                                "max_tokens": 100,
+                                "temperature": 0.1,
+                            },
+                            headers=headers,
+                        )
+                        resp.raise_for_status()
+                        result = resp.json()
+                except httpx.HTTPError as e:
+                    span.set_attribute("error.type", type(e).__name__)
+                    raise HTTPException(status_code=503, detail=f"vLLM unavailable: {e}")
+
+                choice = result["choices"][0]
+                answer = choice["text"].strip()
+                gen_span.set_attribute("gen_ai.response.finish_reasons", [choice.get("finish_reason", "")])
+
+                if "usage" in result:
+                    span.set_attribute("gen_ai.usage.input_tokens", result["usage"].get("prompt_tokens", 0))
+                    span.set_attribute("gen_ai.usage.output_tokens", result["usage"].get("completion_tokens", 0))
+
+    return {"query": body.query, "context": context, "answer": answer}
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/vllm/rag-app/requirements.txt
+++ b/vllm/rag-app/requirements.txt
@@ -1,0 +1,9 @@
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+httpx>=0.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-grpc>=1.27.0
+opentelemetry-instrumentation-fastapi>=0.48b0
+opentelemetry-semantic-conventions>=0.48b0
+opentelemetry-semantic-conventions-ai>=0.4.1
+prometheus-client>=0.21.0

--- a/vllm/scripts/send-request.py
+++ b/vllm/scripts/send-request.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Send sample queries to the RAG app to generate traces and metrics."""
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+RAG_URL = "http://localhost:8001/query"
+
+QUERIES = [
+    "What is OpenTelemetry?",
+    "How does vLLM work?",
+    "Explain distributed tracing",
+    "What is Prometheus used for?",
+    "Tell me about Dash0",
+]
+
+
+def send_query(query: str) -> dict:
+    payload = json.dumps({"query": query}).encode()
+    req = urllib.request.Request(
+        RAG_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    print(f"Sending {len(QUERIES)} queries to {RAG_URL}\n")
+    errors = 0
+
+    for query in QUERIES:
+        print(f"Query:   {query}")
+        try:
+            result = send_query(query)
+            print(f"Context: {result['context'][:80]}...")
+            print(f"Answer:  {result['answer'][:120]}")
+        except urllib.error.URLError as e:
+            print(f"Error:   {e}")
+            errors += 1
+        print()
+
+    if errors:
+        print(f"{errors} request(s) failed — is the RAG app running? (docker compose up)")
+        sys.exit(1)
+
+    print("Done. Check Dash0 for traces and metrics.")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/vllm-server/Dockerfile
+++ b/vllm/vllm-server/Dockerfile
@@ -1,0 +1,6 @@
+FROM vllm/vllm-openai:v0.7.3
+
+RUN pip install --no-cache-dir \
+    opentelemetry-api \
+    opentelemetry-sdk \
+    opentelemetry-exporter-otlp-proto-grpc


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                              
   - Docker Compose demo showing end-to-end vLLM observability with OpenTelemetry                                                                                                                                                             
   - Distributed traces from a FastAPI RAG app through to the vLLM inference engine, connected via W3C trace context propagation                                                                                                              
   - Prometheus metrics from vLLM (`vllm:*` family) scraped by the OTel Collector and forwarded to Dash0                                                                                                                                      
   - GenAI semantic convention attributes (`gen_ai.provider.name`, `gen_ai.request.model`, token usage) on LLM spans                                                                                                                          
   - Setup and cleanup scripts, health checks on all services, GPU requirement documented                                                                                                                                                     
                                                                                                                                                                                                                                              
   ## Test plan                                                                                                                                                                                                                               
                                                                                                                                                                                                                                              
   - [x] Validated end-to-end on `g4dn.xlarge` EC2 instance (NVIDIA T4 GPU)                                                                                                                                                                   
   - [x] Traces confirmed in Dash0 (rag-app waterfall + vllm-server spans linked via traceparent)                                                                                                                                             
   - [x] Metrics confirmed in Dash0 (`vllm:*` metrics flowing via Prometheus scrape)                                                                                                                                                          
   - [x] `python scripts/send-request.py` sends 5 queries successfully                                                                                                                                                                        
   - [x] Fact-checked against Dash0 knowledge base (`/dash0-knowledge-check`) — all claims verified                                                                                                                                           
   - [x] Semantic conventions checked against live OTel spec v1.40.0+ (`/semconv-check`) — deprecated `gen_ai.system` replaced with `gen_ai.provider.name`, `gen_ai.response.finish_reasons` set as array 